### PR TITLE
Issue #114: Added checksum for DB change set 3

### DIFF
--- a/rps-tourney-service-app/src/main/resources/liquibase-change-log.xml
+++ b/rps-tourney-service-app/src/main/resources/liquibase-change-log.xml
@@ -178,6 +178,11 @@
 			#106. -->
 		<validCheckSum>31f186d37ae0605a0f866ba1e47bb3d9</validCheckSum>
 
+		<!-- After upgrading Liquibase from v3.3.2 to v3.5.3 as part of Issue #111,
+			this change set's checksum was coming up as different, even though there
+			were no changes made to it. -->
+		<validCheckSum>90bcfccbd78b4aa501e0d2cbe5d8db8b</validCheckSum>
+
 		<!-- Create the new base table. -->
 		<createTable tableName="LoginIdentities">
 			<column name="id" type="bigint" autoIncrement="${option.autoIncrement}"


### PR DESCRIPTION
I've looked through the history, and I don't have the slightest clue why Liquibase would think this change set is different: it hasn't been modified. Best guess is that it has something to do with the Liquibase
version upgrade.

Issue #114