### PR TITLE
Issue #118: Fix sequence increments

### DIFF
--- a/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/AbstractLoginIdentity.java
+++ b/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/AbstractLoginIdentity.java
@@ -62,7 +62,7 @@ public abstract class AbstractLoginIdentity implements ILoginIdentity, Serializa
 	@Id
 	@Column(name = "`id`", nullable = false, updatable = false)
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "LoginIdentities_id_seq")
-	@SequenceGenerator(name = "LoginIdentities_id_seq", sequenceName = "`loginidentities_id_seq`")
+	@SequenceGenerator(name = "LoginIdentities_id_seq", sequenceName = "`loginidentities_id_seq`", allocationSize = 1)
 	@XmlElement
 	protected long id;
 

--- a/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/Account.java
+++ b/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/Account.java
@@ -77,7 +77,7 @@ public class Account implements Principal, Serializable {
 	@Id
 	@Column(name = "`id`", nullable = false, updatable = false)
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "Accounts_id_seq")
-	@SequenceGenerator(name = "Accounts_id_seq", sequenceName = "`accounts_id_seq`")
+	@SequenceGenerator(name = "Accounts_id_seq", sequenceName = "`accounts_id_seq`", allocationSize = 1)
 	private long id;
 
 	@Column(name = "`createdTimestamp`", nullable = false, updatable = false)

--- a/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/AuditAccountGameMerge.java
+++ b/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/AuditAccountGameMerge.java
@@ -40,7 +40,7 @@ public class AuditAccountGameMerge {
 	@Id
 	@Column(name = "`id`", nullable = false, updatable = false)
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "AuditAccountGameMerges_id_seq")
-	@SequenceGenerator(name = "AuditAccountGameMerges_id_seq", sequenceName = "`auditaccountgamemerges_id_seq`")
+	@SequenceGenerator(name = "AuditAccountGameMerges_id_seq", sequenceName = "`auditaccountgamemerges_id_seq`", allocationSize = 1)
 	private long id;
 
 	@ManyToOne(optional = false, cascade = { CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH,

--- a/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/AuditAccountMerge.java
+++ b/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/auth/AuditAccountMerge.java
@@ -45,7 +45,7 @@ public class AuditAccountMerge {
 	@Id
 	@Column(name = "`id`", nullable = false, updatable = false)
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "AuditAccountMerges_id_seq")
-	@SequenceGenerator(name = "AuditAccountMerges_id_seq", sequenceName = "`auditaccountmerges_id_seq`")
+	@SequenceGenerator(name = "AuditAccountMerges_id_seq", sequenceName = "`auditaccountmerges_id_seq`", allocationSize = 1)
 	private long id;
 
 	@Column(name = "`mergeTimestamp`", nullable = false, updatable = false)

--- a/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/game/Player.java
+++ b/rps-tourney-service-api/src/main/java/com/justdavis/karl/rpstourney/service/api/game/Player.java
@@ -45,7 +45,7 @@ public class Player {
 	@Id
 	@Column(name = "`id`", nullable = false, updatable = false)
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "Players_id_seq")
-	@SequenceGenerator(name = "Players_id_seq", sequenceName = "`players_id_seq`")
+	@SequenceGenerator(name = "Players_id_seq", sequenceName = "`players_id_seq`", allocationSize = 1)
 	@XmlElement
 	private long id;
 

--- a/rps-tourney-service-app/src/main/resources/liquibase-change-log.xml
+++ b/rps-tourney-service-app/src/main/resources/liquibase-change-log.xml
@@ -369,11 +369,11 @@
 		<modifyDataType tableName="AuditAccountGameMerges" columnName="id" newDataType="bigint" />
 		
 		<!-- Add all of the same sequences used in PostgreSQL. -->
-		<createSequence sequenceName="accounts_id_seq" startValue="1" incrementBy="50" />
-		<createSequence sequenceName="players_id_seq" startValue="1" incrementBy="50" />
-		<createSequence sequenceName="loginidentities_id_seq" startValue="1" incrementBy="50" />
-		<createSequence sequenceName="auditaccountmerges_id_seq" startValue="1" incrementBy="50" />
-		<createSequence sequenceName="auditaccountgamemerges_id_seq" startValue="1" incrementBy="50" />
+		<createSequence sequenceName="accounts_id_seq" startValue="1" incrementBy="1" />
+		<createSequence sequenceName="players_id_seq" startValue="1" incrementBy="1" />
+		<createSequence sequenceName="loginidentities_id_seq" startValue="1" incrementBy="1" />
+		<createSequence sequenceName="auditaccountmerges_id_seq" startValue="1" incrementBy="1" />
+		<createSequence sequenceName="auditaccountgamemerges_id_seq" startValue="1" incrementBy="1" />
 
 	</changeSet>
 


### PR DESCRIPTION
This matches how the prod PostgreSQL DB is currently configured. The mismatch between the DB increment and the default Hibernate increment (which was 50) may have been the cause of the errors in Issue #118. Regardless, it's good to get these sync'd up, to prevent confusion in the future.

Not sure if there's a performance case to be made for bumping the increment up, but we can evaluate that later.

Issue #118