### PR TITLE
Issue #122: Turn off the request/response logging in prod.

### DIFF
--- a/rps-tourney-service-app/src/main/resources/logback.xml
+++ b/rps-tourney-service-app/src/main/resources/logback.xml
@@ -29,9 +29,9 @@
 		the application's custom LoggerForInbound and LoggerForOutbound classes, 
 		which attempt to exclude passwords from the log output. -->
 	<logger name="org.apache.cxf.interceptor.LoggingInInterceptor"
-		level="info" />
+		level="warn" />
 	<logger name="org.apache.cxf.interceptor.LoggingOutInterceptor"
-		level="info" />
+		level="warn" />
 
 	<!-- Log at the INFO level and above by default, to the 'FILE' appender. -->
 	<root level="info">


### PR DESCRIPTION
Very useful for debugging in dev! But terribly noisy and insecure for prod.

Issue #122